### PR TITLE
Fix checking out branches.

### DIFF
--- a/src/nimby.nim
+++ b/src/nimby.nim
@@ -219,19 +219,15 @@ proc isGitUrl*(s: string): bool =
   ## Check if a string is a git URL.
   s.startsWith("http://") or s.startsWith("https://") or s.startsWith("git@")
 
-proc extractPackageNameFromUrl*(url: string): string =
-  ## Extract package name from a git URL.
-  var cleanUrl = url
-  if "#" in cleanUrl:
-    cleanUrl = cleanUrl.split("#")[0]
+proc parseGitUrl*(raw: string): tuple[packageName: string, url: string, fragment: string] =
+  ## Parse a git URL into its package name, clean URL, and fragment (branch/tag/commit).
+  let parts = raw.split("#", maxsplit = 1)
+  result.url = parts[0]
+  result.fragment = if parts.len > 1 and parts[1] != "": parts[1] else: ""
+  var cleanUrl = result.url
   if cleanUrl.endsWith(".git"):
     cleanUrl = cleanUrl[0..^5]
-  result = cleanUrl.split("/")[^1]
-
-proc extractUrlFragment*(url: string): string =
-  ## Extract fragment (branch/tag/commit) from URL.
-  if "#" in url:
-    result = url.split("#")[1]
+  result.packageName = cleanUrl.split("/")[^1]
 
 proc parseNimbleFile*(fileName: string): NimbleFile =
   ## Parse the .nimble file and return a NimbleFile object.
@@ -420,12 +416,13 @@ proc isCleanRepo(path: string): bool =
   let outstr = runOnce(&"git -C {path} status --porcelain")
   return outstr == ""
 
-proc cloneRepo(url, path: string, nocheckout = false) =
+proc cloneRepo(url, path: string, nocheckout = false, branch = "") =
+  let branchFlag = if branch != "": &" --branch {branch}" else: ""
   let gitCmd =
     if nocheckout:
-      &"git clone --no-checkout --depth 1 {url} {path}"
+      &"git clone --no-checkout --depth 1{branchFlag} {url} {path}"
     else:
-      &"git clone --depth 1 {url} {path}"
+      &"git clone --depth 1{branchFlag} {url} {path}"
   try:
     runOnce(gitCmd)
   except:
@@ -491,9 +488,7 @@ proc fetchPackage(argument: string) =
   elif isGitUrl(argument):
 
     # Install directly from git URL.
-    let url = argument
-    let packageName = extractPackageNameFromUrl(url)
-    let fragment = extractUrlFragment(url)
+    let (packageName, url, fragment) = parseGitUrl(argument)
     let path =
       if global:
         getGlobalPackagesDir() / packageName
@@ -506,9 +501,7 @@ proc fetchPackage(argument: string) =
       info &"Package already exists: {path}"
       addTreeToConfig(path)
     else:
-      cloneRepo(url, path)
-      if fragment != "":
-        runOnce(&"git -C {path} checkout {fragment}")
+      cloneRepo(url, path, branch = fragment)
     addConfigPackage(packageName)
     print &"Installed package: {packageName}"
     fetchDeps(packageName)

--- a/tests/test_parsing.nim
+++ b/tests/test_parsing.nim
@@ -75,17 +75,26 @@ doAssert isGitUrl("git@github.com:treeform/silky.git") == true, "SSH URL should 
 doAssert isGitUrl("silky") == false, "Package name should not be detected as URL"
 doAssert isGitUrl("") == false, "Empty string should not be detected as URL"
 
-echo "Test 7: extractPackageNameFromUrl extracts package names correctly"
-doAssert extractPackageNameFromUrl("https://github.com/treeform/silky") == "silky", "HTTPS URL without .git"
-doAssert extractPackageNameFromUrl("https://github.com/treeform/shady.git") == "shady", "HTTPS URL with .git"
-doAssert extractPackageNameFromUrl("https://github.com/treeform/shady.git#head") == "shady", "HTTPS URL with fragment"
-doAssert extractPackageNameFromUrl("git@github.com:treeform/vmath.git") == "vmath", "SSH URL"
-doAssert extractPackageNameFromUrl("https://gitea.example.com/user/my-package") == "my-package", "Custom domain"
+echo "Test 7: parseGitUrl parses package name, URL, and fragment correctly"
+var parsed = parseGitUrl("https://github.com/treeform/silky")
+doAssert parsed == ("silky", "https://github.com/treeform/silky", ""), "HTTPS URL without .git"
 
-echo "Test 8: extractUrlFragment extracts fragments correctly"
-doAssert extractUrlFragment("https://github.com/treeform/shady.git#head") == "head", "Fragment after #"
-doAssert extractUrlFragment("https://github.com/treeform/shady.git#v1.0.0") == "v1.0.0", "Version fragment"
-doAssert extractUrlFragment("https://github.com/treeform/shady.git") == "", "No fragment"
-doAssert extractUrlFragment("https://github.com/treeform/shady.git#") == "", "Empty fragment"
+parsed = parseGitUrl("https://github.com/treeform/shady.git")
+doAssert parsed == ("shady", "https://github.com/treeform/shady.git", ""), "HTTPS URL with .git"
+
+parsed = parseGitUrl("https://github.com/treeform/shady.git#head")
+doAssert parsed == ("shady", "https://github.com/treeform/shady.git", "head"), "HTTPS URL with fragment"
+
+parsed = parseGitUrl("git@github.com:treeform/vmath.git")
+doAssert parsed == ("vmath", "git@github.com:treeform/vmath.git", ""), "SSH URL"
+
+parsed = parseGitUrl("https://gitea.example.com/user/my-package")
+doAssert parsed == ("my-package", "https://gitea.example.com/user/my-package", ""), "Custom domain"
+
+parsed = parseGitUrl("https://github.com/treeform/shady.git#v1.0.0")
+doAssert parsed == ("shady", "https://github.com/treeform/shady.git", "v1.0.0"), "Version fragment"
+
+parsed = parseGitUrl("https://github.com/treeform/shady.git#")
+doAssert parsed == ("shady", "https://github.com/treeform/shady.git", ""), "Empty fragment"
 
 echo "All parseNimbleFile and URL helper tests passed."


### PR DESCRIPTION
Although `nimby`'s philosophy is working on `#head`, if a branch is specified in the git url `nimby` tries checking it out after cloning. This does not work due to the cloned repos being `depth=1`.

This patch allows using branches and tags again by cloning with `--branch`. It also unifies the parsing of the git url in a single place to a (packageName, url, fragment) tuple.