### PR TITLE
Support for URL protocols, and ignore #head fragments.

### DIFF
--- a/src/nimby.nim
+++ b/src/nimby.nim
@@ -219,19 +219,31 @@ proc writeHelp() =
   print "  sync       synchronize packages from a lock file"
   print "  help       show this help message"
 
-proc isGitUrl*(s: string): bool =
+proc isGitUrl*(candidate: string): bool =
   ## Check if a string is a git URL.
-  s.startsWith("http://") or s.startsWith("https://") or s.startsWith("git@")
+  let protocols = ["http://", "https://", "ssh://", "git+ssh://", "git@"]
+  for protocol in protocols:
+    if candidate.startsWith(protocol):
+      return true
+  return false
 
 proc parseGitUrl*(raw: string): tuple[packageName: string, url: string, fragment: string] =
   ## Parse a git URL into its package name, clean URL, and fragment (branch/tag/commit).
-  let parts = raw.split("#", maxsplit = 1)
-  result.url = parts[0]
-  result.fragment = if parts.len > 1 and parts[1] != "": parts[1] else: ""
-  var cleanUrl = result.url
-  if cleanUrl.endsWith(".git"):
-    cleanUrl = cleanUrl[0..^5]
-  result.packageName = cleanUrl.split("/")[^1]
+  let
+    parts = raw.split("#", maxsplit = 1)
+    url = parts[0]
+    fragment =
+      if parts.len > 1 and parts[1] != "head":
+        parts[1]
+      else:
+        ""
+    cleanUrl =
+      if url.endsWith(".git"):
+        url[0..^5]
+      else:
+        url
+    packageName = cleanUrl.split("/")[^1]
+  result = (packageName, url, fragment)
 
 proc parseNimbleFile*(fileName: string): NimbleFile =
   ## Parse the .nimble file and return a NimbleFile object.

--- a/tests/test_commands.nim
+++ b/tests/test_commands.nim
@@ -42,10 +42,13 @@ suite "`nimby install` should":
     cmd("nimby install https://github.com/RowDaBoat/nimbytestpackage.git")
     check dirExists("nimbytestpackage")
 
+  #[
+  # TODO: should be moved into treeform to work on CI
   test "work on git urls":
     cmd("nimby install git@github.com:RowDaBoat/nimbytestpackage.git#gitssh-dep")
     check dirExists("nimbytestpackage")
     check branch("nimbytestpackage") == "gitssh-dep"
+  ]#
 
   test "work on branches":
     cmd("nimby install https://github.com/RowDaBoat/nimbytestpackage.git#branch")
@@ -62,6 +65,8 @@ suite "`nimby install` should":
     cmd("nimby install https://github.com/RowDaBoat/nimbytestpackage.git#head")
     check dirExists("nimbytestpackage")
 
+  #[
+  # TODO: should be moved into treeform to work on CI
   test "work on supported ssh urls":
     let protocols = ["ssh://", "git+ssh://"]
 
@@ -71,6 +76,7 @@ suite "`nimby install` should":
       check branch("nimbytestpackage") == "gitssh-dep"
       check dirExists("nimbytestdependency")
       cmd("rm -rf nimbytestpackage nimbytestdependency")
+  ]#
 
 suite "`nimby lock` should":
   setup: clean()

--- a/tests/test_commands.nim
+++ b/tests/test_commands.nim
@@ -14,6 +14,9 @@ proc cmd*(command: string): string {.discardable.} =
 
   return output
 
+proc branch(repo: string): string =
+  cmd(&"git -C {repo} rev-parse --abbrev-ref HEAD").strip
+
 proc clean() =
   ## Resets the test workspace and global nimby directories.
   removeDir(expandTilde("~/.nimby/nimbylock"))
@@ -35,13 +38,39 @@ suite "`nimby install` should":
     check not dirExists("mummy")
     check dirExists(expandTilde("~/.nimby/pkgs/mummy"))
 
+  test "work on https urls":
+    cmd("nimby install https://github.com/RowDaBoat/nimbytestpackage.git")
+    check dirExists("nimbytestpackage")
+
+  test "work on git urls":
+    cmd("nimby install git@github.com:RowDaBoat/nimbytestpackage.git#gitssh-dep")
+    check dirExists("nimbytestpackage")
+    check branch("nimbytestpackage") == "gitssh-dep"
+
   test "work on branches":
     cmd("nimby install https://github.com/RowDaBoat/nimbytestpackage.git#branch")
     check dirExists("nimbytestpackage")
+    check branch("nimbytestpackage") == "branch"
 
   test "resolve dependencies not present in nimble":
     cmd("nimby install https://github.com/RowDaBoat/nimbytestpackage.git#dep-not-in-nimble")
     check dirExists("nimbytestpackage")
+    check branch("nimbytestpackage") == "dep-not-in-nimble"
+    check dirExists("nimbytestdependency")
+
+  test "ignore #head fragments":
+    cmd("nimby install https://github.com/RowDaBoat/nimbytestpackage.git#head")
+    check dirExists("nimbytestpackage")
+
+  test "work on supported ssh urls":
+    let protocols = ["ssh://", "git+ssh://"]
+
+    for protocol in protocols:
+      cmd(&"nimby install {protocol}git@github.com/RowDaBoat/nimbytestpackage.git#gitssh-dep")
+      check dirExists("nimbytestpackage")
+      check branch("nimbytestpackage") == "gitssh-dep"
+      check dirExists("nimbytestdependency")
+      cmd("rm -rf nimbytestpackage nimbytestdependency")
 
 suite "`nimby lock` should":
   setup: clean()
@@ -53,8 +82,6 @@ suite "`nimby lock` should":
     let
       lockOut = readFile("nimbytestpackage.lock")
       lockLines = lockOut.split('\n').filterIt(it.len > 0).toSeq[1..^1].mapIt(it.split(' '))
-
-    let
       expected = @[
         ("bitty", "https://github.com/treeform/bitty"),
         ("boxy", "https://github.com/treeform/boxy"),

--- a/tests/test_parsing.nim
+++ b/tests/test_parsing.nim
@@ -80,21 +80,27 @@ var parsed = parseGitUrl("https://github.com/treeform/silky")
 doAssert parsed == ("silky", "https://github.com/treeform/silky", ""), "HTTPS URL without .git"
 
 parsed = parseGitUrl("https://github.com/treeform/shady.git")
-doAssert parsed == ("shady", "https://github.com/treeform/shady.git", ""), "HTTPS URL with .git"
+doAssert parsed == ("shady", "https://github.com/treeform/shady.git", ""), "HTTPS URL with .git: " & parsed[1]
+
+parsed = parseGitUrl("https://github.com/treeform/shady.git#branch")
+doAssert parsed == ("shady", "https://github.com/treeform/shady.git", "branch"), "HTTPS URL with fragment"
+
+parsed = parseGitUrl("https://github.com/treeform/shady.git#")
+doAssert parsed == ("shady", "https://github.com/treeform/shady.git", ""), "Empty fragment"
 
 parsed = parseGitUrl("https://github.com/treeform/shady.git#head")
-doAssert parsed == ("shady", "https://github.com/treeform/shady.git", "head"), "HTTPS URL with fragment"
+doAssert parsed == ("shady", "https://github.com/treeform/shady.git", ""), "Empty fragment"
 
 parsed = parseGitUrl("git@github.com:treeform/vmath.git")
-doAssert parsed == ("vmath", "git@github.com:treeform/vmath.git", ""), "SSH URL"
+doAssert parsed == ("vmath", "git@github.com:treeform/vmath.git", ""), "SSH URL without protocol"
+
+parsed = parseGitUrl("ssh://git@github.com:treeform/shady.git#fragment")
+doAssert parsed == ("shady", "ssh://git@github.com:treeform/shady.git", "fragment"), "SSH URL with protocol"
 
 parsed = parseGitUrl("https://gitea.example.com/user/my-package")
 doAssert parsed == ("my-package", "https://gitea.example.com/user/my-package", ""), "Custom domain"
 
 parsed = parseGitUrl("https://github.com/treeform/shady.git#v1.0.0")
 doAssert parsed == ("shady", "https://github.com/treeform/shady.git", "v1.0.0"), "Version fragment"
-
-parsed = parseGitUrl("https://github.com/treeform/shady.git#")
-doAssert parsed == ("shady", "https://github.com/treeform/shady.git", ""), "Empty fragment"
 
 echo "All parseNimbleFile and URL helper tests passed."


### PR DESCRIPTION
Package URL's can have `ssh://` or `git+ssh://` protocol prefixes. Currently, `nimby` does not take those as valid git-urls, and tries to fetch the whole URL as a nimble package. `ssh` and `git+ssh` were added to the checks for now, maybe we should propose a more robust solution later.

Currently, a `#head` fragment will be taken as a branch, since it's a special case, and `nimby` by default clones the top main branch, I just added a condition to ignore it.