### PR TITLE
Add a `lock build` command

### DIFF
--- a/.github/workflows/nimby_speed.yml
+++ b/.github/workflows/nimby_speed.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Compile Nimby
         run: nim c -d:release src/nimby.nim
 
+      - name: Create Nimby Workspace
+        run: src/nimby create
+
       - name: Test Speed
         run: src/nimby install fidget2
 

--- a/.github/workflows/test_from_nothing.yml
+++ b/.github/workflows/test_from_nothing.yml
@@ -80,9 +80,7 @@ jobs:
           echo "$HOME/.nimby/nim/bin" >> "$GITHUB_PATH"
 
       - name: Install Fidget2
-        run: |
-          nimby create
-          nimby install fidget2
+        run: nimby install fidget2
 
       - name: List Installed Nim packages
         run: nimby list

--- a/.github/workflows/test_from_nothing.yml
+++ b/.github/workflows/test_from_nothing.yml
@@ -80,7 +80,9 @@ jobs:
           echo "$HOME/.nimby/nim/bin" >> "$GITHUB_PATH"
 
       - name: Install Fidget2
-        run: nimby install fidget2
+        run: |
+          nimby create
+          nimby install fidget2
 
       - name: List Installed Nim packages
         run: nimby list

--- a/.github/workflows/test_install_from_file.yml
+++ b/.github/workflows/test_install_from_file.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Compile Nimby
         run: nim c -d:release -d:monkey src/nimby.nim
 
+      - name: Create Nimby Workspace
+        run: src/nimby create
+
       - name: Boxy
         run: git clone --depth 1 https://github.com/treeform/boxy.git
 

--- a/.github/workflows/test_sync_lock_file.yml
+++ b/.github/workflows/test_sync_lock_file.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Compile Nimby
         run: nim c -d:release -d:monkey src/nimby.nim
 
+      - name: Create Nimby Workspace
+        run: src/nimby create
+
       - name: Sync Test Lock File
         run: src/nimby sync tests/nimby.lock
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,17 @@
 Nimby is the fastest and simplest way to install Nim packages.
 It keeps things honest, transparent, and lightning fast.
 
-Instead of magic, Nimby just uses git. It clones repositories directly into your workspace, reads their `.nimble` files, and installs dependencies in parallel. Everything is shallow cloned, HEAD by design, and written straight into your `nim.cfg`.
+## Quick Start
 
-You can also install globally with `-g` in `~/.nimby/pkgs` folder. Nimby can install the Nim compiler itself as well in the `~/.nimby/nim/bin` folder. With two commands you can download Nim and install all your packages, and be ready to build in seconds around 14 seconds.
-
----
+```sh
+curl -L -o nimby https://github.com/treeform/nimby/releases/download/0.1.27/nimby-Linux-X64
+chmod +x nimby
+./nimby use 2.2.10
+./nimby create
+./nimby install library
+./nimby lock library > library/nimby.lock
+./nimby sync library/nimby.lock
+```
 
 ## Why Nimby exists
 
@@ -36,7 +42,11 @@ After that, nimby grew form a few basic ideas:
 * Always grab `#HEAD`.
 * Do everything in parallel.
 
-## How to use:
+Instead of magic, Nimby just uses git. It clones repositories directly into your workspace, reads their `.nimble` files, and installs dependencies in parallel. Packages are shallow-cloned, checked out at HEAD by design, and written straight into your `nim.cfg`.
+
+You can also install globally with `-g` in the `~/.nimby/pkgs` folder. Nimby can install the Nim compiler itself into the `~/.nimby/nim/bin` folder. With two commands, you can download Nim, install all your packages, and be ready to build in about 14 seconds.
+
+## How to use
 
 * Create a workspace with `nimby create` in the folder where you want packages to live.
 * Install with `nimby install library` for development.
@@ -49,31 +59,31 @@ After that, nimby grew form a few basic ideas:
   ```
 * Crate a lock file with `nimby lock project > project/nimby.lock`.
   ```
-  libraryA 1.0.0 https://github.com/treeform/librar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  libraryA 1.0.0 https://github.com/treeform/library xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
   ```
-* During CI and deploy use lock `nimby sync project/nimby.lock`.
+* For CI and deploys, use the lock file with `nimby sync project/nimby.lock`.
   ```
   workspace/
     nim.cfg
     project/
-    library
+    library/
   ```
 
 ## Why always install HEAD?
 
-Well, the Nim community is small, and it doesn’t really have the packaging culture that other languages do. And that’s fine. In a way, it’s actually freeing!
+Well, the Nim community is small, and it doesn't really have the packaging culture that other languages do. And that's fine. In a way, it's actually freeing!
 
-But it also means that people rarely test older versions of packages against older versions of other packages. It's just boring thankless work after all.
+But it also means that people rarely test older versions of packages against older versions of other packages. It's boring, thankless work after all.
 
-This makes a lot of the version numbers in requirements you see in `.nimble` files don’t really reflect reality. They might claim that a version is supported, but in practice, no one tests the old stuff. And that’s okay. It’s just how the community works.
+Because of that, many version requirements in `.nimble` files don't really reflect reality. They might claim that a version is supported, but in practice, no one tests the old stuff. And that's okay. It's just how the community works.
 
 So Nimby follows the community approach and always checks out HEAD, because HEAD has the highest chance of working. Even if an API has changed, we now have AI tools that can help fix minor API changes.
 
 For development, installing from HEAD is the best way to move forward. It keeps everything current and in sync with how people actually develop Nim projects. It avoids diamond dependencies (where your package depends on A and B, but A and B depend on conflicting versions of C) and keeps things simple. I love simple things.
 
-But installing from HEAD is not good for CI, releases, or deployment to production. That’s where lock files come in. Since the development process relies on HEAD, lock files give you a way to record exactly what worked at a given moment in time for the deployment process.
+But installing from HEAD is not good for CI, releases, or deployment to production. That's where lock files come in. Since the development process relies on HEAD, lock files give you a way to record exactly what worked at a given moment in time for the deployment process.
 
-Generating a lock file is easy. Commit it along with your code, and when you need to reproduce a build, Nimby can install the exact dependencies and commits listed in that file just run `nimby sync repo/nimby.lock`. It's just a simple text file that lists package names, URLs, and commits.
+Generating a lock file is easy. Commit it along with your code. When you need to reproduce a build, just run `nimby sync repo/nimby.lock`; Nimby will install the exact dependencies and commits listed in that file. It's a simple text file that lists package names, URLs, and commits.
 
 ## What is the deal with the workspace folder?
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ curl -L -o nimby https://github.com/treeform/nimby/releases/download/0.1.27/nimb
 chmod +x nimby
 ./nimby use 2.2.10
 ./nimby create
-./nimby install library
+./nimby install libraryA libraryB libraryC
 ./nimby lock library > library/nimby.lock
 ./nimby sync library/nimby.lock
 ```
@@ -49,24 +49,30 @@ You can also install globally with `-g` in the `~/.nimby/pkgs` folder. Nimby can
 ## How to use
 
 * Create a workspace with `nimby create` in the folder where you want packages to live.
-* Install with `nimby install library` for development.
+* Install with `nimby install libraryA libraryB libraryC` for development.
 * Keep your project alongside its dependencies in the workspace.
   ```
   workspace/
     nim.cfg
     project/
-    library/
+    libraryA/
+    libraryB/
+    libraryC/
   ```
 * Create a lock file with `nimby lock project > project/nimby.lock`.
   ```
-  library 1.0.0 https://github.com/treeform/library xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  libraryA 1.0.0 https://github.com/treeform/libraryA xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  libraryB 1.0.0 https://github.com/treeform/libraryB xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  libraryC 1.0.0 https://github.com/treeform/libraryC xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
   ```
 * For CI and deployments, use the lock file with `nimby sync project/nimby.lock`.
   ```
   workspace/
     nim.cfg
     project/
-    library/
+    libraryA/
+    libraryB/
+    libraryC/
   ```
 
 ## Why always install HEAD?
@@ -226,6 +232,13 @@ Installing package: silky
 Installed package: silky
 ```
 
+You can install several packages in one command, with spaces or commas:
+
+```sh skip
+nimby install libraryA libraryB libraryC
+nimby install libraryA, libraryB, libraryC
+```
+
 Global installs use `~/.nimby/pkgs` instead of the current workspace:
 
 ```sh skip
@@ -261,7 +274,7 @@ Usage: nimby <subcommand> [options]
     -V, --verbose print verbose output
 Subcommands:
   create     create a Nimby workspace in the current directory
-  install    install all Nim packages in the current directory
+  install    install Nim packages into the current workspace
   update     update all Nim packages in the current directory
   remove     remove all Nim packages in the current directory
   list       list all Nim packages in the current directory

--- a/README.md
+++ b/README.md
@@ -21,9 +21,43 @@ You can also install globally with `-g` in `~/.nimby/pkgs` folder. Nimby can ins
 
 When I added Nim to our company CI, our builds suddenly became very slow. Nimble installs took almost two minutes for Fidget2. That felt wrong, so I started digging.
 
-I tried replacing Nimble with a few simple shell scripts that just cloned the repos with git. It built fine, and was way way faster! 2 minutes vs 3 seconds faster.
+I tried replacing Nimble with a few simple shell scripts that just cloned the repos with git. It built fine, and was way way faster! So then I wrote nimby as a tool to just clone everything in parallel:
 
-So Nimby started from a simple idea: download Nim packages from git, do not resolve dependencies, and in parallel.
+* Nimble: 2 minutes
+* Nimby: 3 seconds
+
+At its core, nimby is does `git clone` and upates `nim.cfg` in the workspace folder.
+
+After that, nimby grew form a few basic ideas:
+
+* Have a single workspace folder.
+* Download Nim packages using git.
+* Do not resolve dependencies.
+* Always grab `#HEAD`.
+* Do everything in parallel.
+
+## How to use:
+
+* Create a workspace with `nimby create` in the folder where you want packages to live.
+* Install with `nimby install library` for development.
+* Develop your project alongside the dependencies in the `project` folder.
+  ```
+  workspace/
+    nim.cfg
+    project/
+    library/
+  ```
+* Crate a lock file with `nimby lock project > project/nimby.lock`.
+  ```
+  libraryA 1.0.0 https://github.com/treeform/librar xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  ```
+* During CI and deploy use lock `nimby sync project/nimby.lock`.
+  ```
+  workspace/
+    nim.cfg
+    project/
+    library
+  ```
 
 ## Why always install HEAD?
 
@@ -37,24 +71,19 @@ So Nimby follows the community approach and always checks out HEAD, because HEAD
 
 For development, installing from HEAD is the best way to move forward. It keeps everything current and in sync with how people actually develop Nim projects. It avoids diamond dependencies (where your package depends on A and B, but A and B depend on conflicting versions of C) and keeps things simple. I love simple things.
 
-But installing from HEAD is not good for CI, releases, or deployment to production. That’s where lock files come in. Since the community relies on HEAD, lock files give you a way to record exactly what worked at a given moment in time.
+But installing from HEAD is not good for CI, releases, or deployment to production. That’s where lock files come in. Since the development process relies on HEAD, lock files give you a way to record exactly what worked at a given moment in time for the deployment process.
 
-Generating a lock file is easy. Commit it along with your code, and when you need to reproduce a build, Nimby can install the exact dependencies and commits listed in that file. It's just a simple text file that lists package names, URLs, and commits.
-
-So the model is simple: use HEAD (`nimby install`) for development, and use lock files for deployment (`nimby sync`). It’s the best of both worlds.
-It's a simple text file that lists package names, URLs, and commits.
-
+Generating a lock file is easy. Commit it along with your code, and when you need to reproduce a build, Nimby can install the exact dependencies and commits listed in that file just run `nimby sync repo/nimby.lock`. It's just a simple text file that lists package names, URLs, and commits.
 
 ## What is the deal with the workspace folder?
 
-Create a workspace with `nimby create` in the folder where you want packages to
-live. After that, you can run commands from inside any package or subdirectory
-and Nimby will walk upward until it finds that workspace. If no workspace exists,
-Nimby will create one automatically only in plain directories. Inside a Git
-checkout or a Nimble package, it stops and asks you to run `nimby create` in the
-directory you really want as the workspace.
+Create a workspace with `nimby create` in the folder where you want packages to live.
+After that, you can run commands from inside any package or subdirectory and Nimby will walk upward until it finds that workspace.
+If no workspace exists, Nimby will create one automatically only in plain directories.
+Inside a Git checkout or a Nimble package, it stops and asks you to run `nimby create` in the directory you really want as the workspace.
 
 I think the workspace folder is great. The way I have things set up, there’s a single Nim config file, and all the packages I’m working on live together as simple git checkouts.
+
 Alongside them, I also keep clones of all the dependencies I use. Everything lives in one place:
 
 ```
@@ -82,7 +111,7 @@ The global option works for both `nimby install -g` and even more importantly `n
 
 Yeah, installing Nim is actually pretty easy. You just copy a couple of folders, put them in the right place, and add `~/.nimby/nim/bin` to your system path. That’s it.
 
-I think it’s a great addition to have in Nimby because it makes setup incredibly simple. You can just curl the Nimby binary for your system `curl -L -o nimby https://github.com/treeform/nimby/releases/download/0.1.27/nimby-Linux-X64`, and that’s all you need. Then you run `./nimby use 2.2.10` with the Nim version you want, and `./nimby install your/nimby.lock` with your lock file.
+I think it’s a great addition to have in Nimby because it makes setup incredibly simple. You can just curl the Nimby binary for your system `curl -L -o nimby https://github.com/treeform/nimby/releases/download/0.1.27/nimby-Linux-X64`, and that’s all you need. Then you run `./nimby use 2.2.10` with the Nim version you want, and `./nimby sync your/nimby.lock` with your lock file.
 
 This works perfectly for CI workflows, deployments, or any situation where you’re starting with a blank machine. You don’t need to install anything else. Nimby downloads Nim, installs your packages, and you’re ready to go.
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Install from a lock file:
 mkdir synced
 cp nimby.lock synced/
 cd synced
+nimby create >/dev/null
 nimby sync nimby.lock 2>&1 | sed -n '/^Installed package: chroma$/p'
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 `nimble install nimby`
 
-![Github Actions](https://github.com/treeform/nimby/workflows/Github%20Actions/badge.svg)
+![GitHub Actions](https://github.com/treeform/nimby/workflows/Github%20Actions/badge.svg)
 
 [API reference](https://treeform.github.io/nimby)
 
@@ -13,7 +13,7 @@ It keeps things honest, transparent, and lightning fast.
 
 ## Quick Start
 
-```sh
+```sh skip
 curl -L -o nimby https://github.com/treeform/nimby/releases/download/0.1.27/nimby-Linux-X64
 chmod +x nimby
 ./nimby use 2.2.10
@@ -27,14 +27,14 @@ chmod +x nimby
 
 When I added Nim to our company CI, our builds suddenly became very slow. Nimble installs took almost two minutes for Fidget2. That felt wrong, so I started digging.
 
-I tried replacing Nimble with a few simple shell scripts that just cloned the repos with git. It built fine, and was way way faster! So then I wrote nimby as a tool to just clone everything in parallel:
+I tried replacing Nimble with a few simple shell scripts that just cloned the repos with git. It built fine, and was way, way faster! So then I wrote Nimby as a tool to clone everything in parallel:
 
 * Nimble: 2 minutes
 * Nimby: 3 seconds
 
-At its core, nimby is does `git clone` and upates `nim.cfg` in the workspace folder.
+At its core, Nimby runs `git clone` and updates `nim.cfg` in the workspace folder.
 
-After that, nimby grew form a few basic ideas:
+After that, Nimby grew from a few basic ideas:
 
 * Have a single workspace folder.
 * Download Nim packages using git.
@@ -42,7 +42,7 @@ After that, nimby grew form a few basic ideas:
 * Always grab `#HEAD`.
 * Do everything in parallel.
 
-Instead of magic, Nimby just uses git. It clones repositories directly into your workspace, reads their `.nimble` files, and installs dependencies in parallel. Packages are shallow-cloned, checked out at HEAD by design, and written straight into your `nim.cfg`.
+Instead of magic, Nimby just uses git. It clones repositories directly into your workspace, reads their `.nimble` files, and installs dependencies in parallel. Packages are shallow-cloned and checked out at HEAD by design, and their paths are written straight into your `nim.cfg`.
 
 You can also install globally with `-g` in the `~/.nimby/pkgs` folder. Nimby can install the Nim compiler itself into the `~/.nimby/nim/bin` folder. With two commands, you can download Nim, install all your packages, and be ready to build in about 14 seconds.
 
@@ -50,18 +50,18 @@ You can also install globally with `-g` in the `~/.nimby/pkgs` folder. Nimby can
 
 * Create a workspace with `nimby create` in the folder where you want packages to live.
 * Install with `nimby install library` for development.
-* Develop your project alongside the dependencies in the `project` folder.
+* Keep your project alongside its dependencies in the workspace.
   ```
   workspace/
     nim.cfg
     project/
     library/
   ```
-* Crate a lock file with `nimby lock project > project/nimby.lock`.
+* Create a lock file with `nimby lock project > project/nimby.lock`.
   ```
-  libraryA 1.0.0 https://github.com/treeform/library xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+  library 1.0.0 https://github.com/treeform/library xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
   ```
-* For CI and deploys, use the lock file with `nimby sync project/nimby.lock`.
+* For CI and deployments, use the lock file with `nimby sync project/nimby.lock`.
   ```
   workspace/
     nim.cfg
@@ -73,7 +73,7 @@ You can also install globally with `-g` in the `~/.nimby/pkgs` folder. Nimby can
 
 Well, the Nim community is small, and it doesn't really have the packaging culture that other languages do. And that's fine. In a way, it's actually freeing!
 
-But it also means that people rarely test older versions of packages against older versions of other packages. It's boring, thankless work after all.
+But it also means that people rarely test older versions of packages against older versions of other packages. It's boring, thankless work, after all.
 
 Because of that, many version requirements in `.nimble` files don't really reflect reality. They might claim that a version is supported, but in practice, no one tests the old stuff. And that's okay. It's just how the community works.
 
@@ -81,7 +81,7 @@ So Nimby follows the community approach and always checks out HEAD, because HEAD
 
 For development, installing from HEAD is the best way to move forward. It keeps everything current and in sync with how people actually develop Nim projects. It avoids diamond dependencies (where your package depends on A and B, but A and B depend on conflicting versions of C) and keeps things simple. I love simple things.
 
-But installing from HEAD is not good for CI, releases, or deployment to production. That's where lock files come in. Since the development process relies on HEAD, lock files give you a way to record exactly what worked at a given moment in time for the deployment process.
+But installing from HEAD is not good for CI, releases, or deployment to production. That's where lock files come in. Since the development process relies on HEAD, lock files give you a way to record exactly what worked at a given moment in time for deployment.
 
 Generating a lock file is easy. Commit it along with your code. When you need to reproduce a build, just run `nimby sync repo/nimby.lock`; Nimby will install the exact dependencies and commits listed in that file. It's a simple text file that lists package names, URLs, and commits.
 
@@ -89,10 +89,10 @@ Generating a lock file is easy. Commit it along with your code. When you need to
 
 Create a workspace with `nimby create` in the folder where you want packages to live.
 After that, you can run commands from inside any package or subdirectory and Nimby will walk upward until it finds that workspace.
-If no workspace exists, Nimby will create one automatically only in plain directories.
+If no workspace exists, Nimby will only create one automatically in plain directories.
 Inside a Git checkout or a Nimble package, it stops and asks you to run `nimby create` in the directory you really want as the workspace.
 
-I think the workspace folder is great. The way I have things set up, there’s a single Nim config file, and all the packages I’m working on live together as simple git checkouts.
+I think the workspace folder is great. The way I have things set up, there's a single Nim config file, and all the packages I'm working on live together as simple git checkouts.
 
 Alongside them, I also keep clones of all the dependencies I use. Everything lives in one place:
 
@@ -107,23 +107,23 @@ workspace/
   ..
 ```
 
-This makes it much easier to move around and explore the code base. If I’m developing something and want to see what a function does inside one of the dependencies, I can just open it right there. No hunting through hidden directories or special paths.
+This makes it much easier to move around and explore the codebase. If I'm developing something and want to see what a function does inside one of the dependencies, I can just open it right there. No hunting through hidden directories or special paths.
 
 It also helps modern AI tools. Since everything sits in one folder, they can read and understand the source code of all your dependencies at once, giving you better suggestions and context.
 
 I never liked it when packages get installed into hidden folders deep in your home directory, or when they end up scattered inside things like `deps` or `nim_modules`. It feels messy. I like everything to be clean and simple, and having all your checkouts in one visible folder is the simplest way I can think of.
 
-Not everyone develops like this, though. Sometimes you just need a tool globally and don’t want it sitting in your workspace. That’s why I added the `-g` or `--global` flag. It installs packages in a global Nimby folder `~/.nimby/pkgs` instead of the local workspace. This is especially handy for CI setups or for people who only need to use packages, not develop them.
+Not everyone develops like this, though. Sometimes you just need a tool globally and don't want it sitting in your workspace. That's why I added the `-g` or `--global` flag. It installs packages in the global Nimby folder, `~/.nimby/pkgs`, instead of the local workspace. This is especially handy for CI setups or for people who only need to use packages, not develop them.
 
-The global option works for both `nimby install -g` and even more importantly `nimby sync -g` when you’re working with lock files. That’s really all there is to it.
+The global option works for both `nimby install -g` and, even more importantly, `nimby sync -g` when you're working with lock files. That's really all there is to it.
 
 ## What? It also installs Nim itself?
 
-Yeah, installing Nim is actually pretty easy. You just copy a couple of folders, put them in the right place, and add `~/.nimby/nim/bin` to your system path. That’s it.
+Yeah, installing Nim is actually pretty easy. You just copy a couple of folders, put them in the right place, and add `~/.nimby/nim/bin` to your system path. That's it.
 
-I think it’s a great addition to have in Nimby because it makes setup incredibly simple. You can just curl the Nimby binary for your system `curl -L -o nimby https://github.com/treeform/nimby/releases/download/0.1.27/nimby-Linux-X64`, and that’s all you need. Then you run `./nimby use 2.2.10` with the Nim version you want, and `./nimby sync your/nimby.lock` with your lock file.
+I think it's a great addition to have in Nimby because it makes setup incredibly simple. You can just curl the Nimby binary for your system, `curl -L -o nimby https://github.com/treeform/nimby/releases/download/0.1.27/nimby-Linux-X64`, and that's all you need. Then you run `./nimby use 2.2.10` with the Nim version you want, and `./nimby sync your/nimby.lock` with your lock file.
 
-This works perfectly for CI workflows, deployments, or any situation where you’re starting with a blank machine. You don’t need to install anything else. Nimby downloads Nim, installs your packages, and you’re ready to go.
+This works perfectly for CI workflows, deployments, or any situation where you're starting with a blank machine. You don't need to install anything else. Nimby downloads Nim, installs your packages, and you're ready to go.
 
 ---
 
@@ -167,6 +167,9 @@ Nimby can install Nim itself into `~/.nimby/nim`:
 ```sh skip
 nimby use 2.2.10
 ```
+
+`nimby use <version>` downloads that Nim version and makes it the active Nim
+compiler under `~/.nimby/nim`.
 
 After that, add Nim's bin directory to `PATH`.
 
@@ -266,6 +269,7 @@ Subcommands:
   doctor     diagnose all packages and fix linking issues
   lock       generate a lock file for a package
   sync       synchronize packages from a lock file
+  use        install a Nim compiler version
   help       show this help message
 ```
 
@@ -323,8 +327,8 @@ nimby update silky 2>&1 | sed -n '/^Updated package: silky$/p'
 Updated package: silky
 ```
 
-`update --all` updates both workspace and global packages. It asks before doing
-that, so use `-y` only when the command is already intentional:
+`update --all` updates both workspace and global packages. It prompts first, so
+use `-y` only when the command is already intentional:
 
 ```sh
 nimby update --all -y >/dev/null && echo "Updated all packages"
@@ -355,7 +359,7 @@ nimby sync -g nimby.lock 2>&1 | sed -n '/^Installed package: chroma$/p'
 Installed package: chroma
 ```
 
-This is similar to how Cargo, npm, and other package managers use lock files, but kept as simple text that lists package names, URLs, and commits.
+This is similar to how Cargo, npm, and other package managers use lock files, but it is kept as a simple text file that lists package names, URLs, and commits.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ It's a simple text file that lists package names, URLs, and commits.
 
 ## What is the deal with the workspace folder?
 
-You always should run `nimby` commands from the workspace folder just like you would with `git clone`. It's not wrong to think of nimby like a `git clone` with extra steps.
+Create a workspace with `nimby create` in the folder where you want packages to
+live. After that, you can run commands from inside any package or subdirectory
+and Nimby will walk upward until it finds that workspace. If no workspace exists,
+Nimby will create one automatically only in plain directories. Inside a Git
+checkout or a Nimble package, it stops and asks you to run `nimby create` in the
+directory you really want as the workspace.
 
 I think the workspace folder is great. The way I have things set up, there’s a single Nim config file, and all the packages I’m working on live together as simple git checkouts.
 Alongside them, I also keep clones of all the dependencies I use. Everything lives in one place:
@@ -213,6 +218,7 @@ Usage: nimby <subcommand> [options]
     -h, --help show this help message
     -V, --verbose print verbose output
 Subcommands:
+  create     create a Nimby workspace in the current directory
   install    install all Nim packages in the current directory
   update     update all Nim packages in the current directory
   remove     remove all Nim packages in the current directory

--- a/README.md
+++ b/README.md
@@ -235,8 +235,7 @@ Installed package: silky
 You can install several packages in one command, with spaces or commas:
 
 ```sh skip
-nimby install libraryA libraryB libraryC
-nimby install libraryA, libraryB, libraryC
+nimby install taggy, orbits, stenography
 ```
 
 Global installs use `~/.nimby/pkgs` instead of the current workspace:

--- a/README.md
+++ b/README.md
@@ -272,17 +272,18 @@ Usage: nimby <subcommand> [options]
     -h, --help show this help message
     -V, --verbose print verbose output
 Subcommands:
-  create     create a Nimby workspace in the current directory
-  install    install Nim packages into the current workspace
-  update     update all Nim packages in the current directory
-  remove     remove all Nim packages in the current directory
-  list       list all Nim packages in the current directory
-  tree       show all packages as a dependency tree
-  doctor     diagnose all packages and fix linking issues
-  lock       generate a lock file for a package
-  sync       synchronize packages from a lock file
-  use        install a Nim compiler version
-  help       show this help message
+  create        create a Nimby workspace in the current directory
+  install       install Nim packages into the current workspace
+  update        update all Nim packages in the current directory
+  remove        remove all Nim packages in the current directory
+  list          list all Nim packages in the current directory
+  tree          show all packages as a dependency tree
+  doctor        diagnose all packages and fix linking issues
+  lock          generate a lock file for a package
+  lock build    build a package after verifying locked dependencies
+  sync          synchronize packages from a lock file
+  use           install a Nim compiler version
+  help          show this help message
 ```
 
 ## Working with lock files

--- a/src/nimby.nim
+++ b/src/nimby.nim
@@ -11,6 +11,9 @@ when defined(monkey):
 const
   WorkerCount = 4
   lockDir = "nimbylock"
+  workspaceFile = "nim.cfg"
+  workspaceMarker = "# Managed by Nimby"
+  legacyWorkspaceMarker = "# Created by Nimby"
 
 type
   NimbyError* = object of CatchableError
@@ -145,6 +148,73 @@ proc writeFileSafe(fileName: string, content: string) =
           sleep(100 * trying)
       raise newException(NimbyError, "error writing file `" & fileName & "`: " & getCurrentExceptionMsg())
 
+proc hasMarker(content: string): bool =
+  ## Check whether config text has a Nimby workspace marker.
+  for line in content.splitLines():
+    let stripped = line.strip()
+    if stripped == workspaceMarker or stripped == legacyWorkspaceMarker:
+      return true
+
+proc createWorkspace*(path: string = getCurrentDir(), announce = true) =
+  ## Create a Nimby workspace in exactly this directory.
+  let nimCfgPath = path / workspaceFile
+  if fileExists(nimCfgPath):
+    var nimCfg = readFileSafe(nimCfgPath)
+    if hasMarker(nimCfg):
+      if announce:
+        print &"Nimby workspace already exists: {path}"
+      return
+    if nimCfg.len > 0 and not nimCfg.endsWith("\n"):
+      nimCfg.add "\n"
+    writeFileSafe(nimCfgPath, workspaceMarker & "\n" & nimCfg)
+  else:
+    writeFileSafe(nimCfgPath, workspaceMarker & "\n")
+  if announce:
+    print &"Created Nimby workspace: {path}"
+
+proc containsNimbleFile(path: string): bool =
+  ## Check whether a directory contains a Nimble package file.
+  for kind, child in walkDir(path):
+    if kind == pcFile and child.endsWith(".nimble"):
+      return true
+
+proc findBoundary(startDir: string): string =
+  ## Find the nearest Git checkout or Nimble package directory.
+  var dir = startDir
+  while true:
+    if dirExists(dir / ".git") or containsNimbleFile(dir):
+      return dir
+    let parent = parentDir(dir)
+    if parent == "" or parent == dir:
+      return ""
+    dir = parent
+
+proc findWorkspace*(startDir: string = getCurrentDir(), autoCreate = true): string =
+  ## Find the nearest Nimby workspace, or create one when safe.
+  var dir = startDir
+  while true:
+    let nimCfgPath = dir / workspaceFile
+    if fileExists(nimCfgPath) and hasMarker(readFileSafe(nimCfgPath)):
+      return dir
+    let parent = parentDir(dir)
+    if parent == "" or parent == dir:
+      break
+    dir = parent
+
+  if not autoCreate:
+    nimbyQuit("No Nimby workspace found. Run `nimby create` in the directory you want as the workspace.")
+
+  let boundary = findBoundary(startDir)
+  if boundary != "":
+    nimbyQuit(
+      "No Nimby workspace found.\n" &
+      &"Refusing to create one inside package or Git checkout: {boundary}\n" &
+      "Run `nimby create` in the directory you want as the workspace."
+    )
+
+  createWorkspace(startDir, announce = false)
+  return startDir
+
 proc runOnce(command: string): string {.discardable.} =
   # Returns stdout
   let exeName = command.split(" ")[0]
@@ -209,6 +279,7 @@ proc writeHelp() =
   print "    -h, --help show this help message"
   print "    -V, --verbose print verbose output"
   print "Subcommands:"
+  print "  create     create a Nimby workspace in the current directory"
   print "  install    install all Nim packages in the current directory"
   print "  update     update all Nim packages in the current directory"
   print "  remove     remove all Nim packages in the current directory"
@@ -413,19 +484,19 @@ proc addConfigDir(path: string) =
   ## Add a directory to the nim.cfg file.
   withLock(jobLock):
     let path = path.replace("\\", "/") # Always use Linux-style paths.
-    if not fileExists("nim.cfg"):
-      writeFileSafe("nim.cfg", "# Created by Nimby\n")
-    var nimCfg = readFileSafe("nim.cfg")
+    if not fileExists(workspaceFile) or not hasMarker(readFileSafe(workspaceFile)):
+      createWorkspace(getCurrentDir(), announce = false)
+    var nimCfg = readFileSafe(workspaceFile)
     if nimCfg.contains(&"--path:\"{path}\""):
       return
     let line = &"--path:\"{path}\"\n"
     info &"Adding nim.cfg line: {line.strip()}"
     nimCfg.add(line)
-    writeFileSafe("nim.cfg", nimCfg)
+    writeFileSafe(workspaceFile, nimCfg)
 
 proc addConfigPackage(name: string) =
   ## Add a package to the nim.cfg file.
-  try: 
+  try:
     let package = getNimbleFile(name)
     addConfigDir(package.installDir / package.srcDir)
   except NimbleFileNotFound as e:
@@ -435,14 +506,14 @@ proc addConfigPackage(name: string) =
 proc removeConfigDir(path: string) =
   ## Remove a directory from the nim.cfg file.
   withLock(jobLock):
-    var nimCfg = readFileSafe("nim.cfg")
+    var nimCfg = readFileSafe(workspaceFile)
     var lines = nimCfg.splitLines()
     for i, line in lines:
       if line.contains(&"--path:\"{path}\""):
         lines.delete(i)
         break
     nimCfg = lines.join("\n")
-    writeFileSafe("nim.cfg", lines.join("\n"))
+    writeFileSafe(workspaceFile, lines.join("\n"))
 
 proc removeConfigPackage(name: string) =
   ## Remove the package from the nim.cfg file.
@@ -590,17 +661,47 @@ proc fetchPackage(argument: string) =
     else:
       nimbyQuit(&"Unknown method {methodKind} for fetching package {name}")
 
+proc normalizePathArgument(argument, startDir: string): string =
+  ## Preserve path arguments relative to the user's original directory.
+  if argument == "":
+    return argument
+  let candidate =
+    if argument.isAbsolute:
+      argument
+    else:
+      startDir / argument
+  if fileExists(candidate) or dirExists(candidate):
+    return candidate
+  argument
+
+proc prepareWorkspace() =
+  ## Move to the nearest Nimby workspace root.
+  setCurrentDir(findWorkspace(getCurrentDir()))
+
+proc prepareWorkspace(argument: string): string =
+  ## Move to the nearest Nimby workspace root and return a preserved path argument.
+  let startDir = getCurrentDir()
+  result = normalizePathArgument(argument, startDir)
+  setCurrentDir(findWorkspace(startDir))
+
 proc installPackage(argument: string) =
   ## Install a package.
-  timeStart()
-  print &"Installing package: {argument}"
+  let packageArg =
+    if argument.endsWith(".nimble"):
+      prepareWorkspace(argument)
+    else:
+      prepareWorkspace()
+      argument
 
-  if dirExists(argument):
+  timeStart()
+  print &"Installing package: {packageArg}"
+
+  if dirExists(packageArg):
     nimbyQuit("Package already installed.")
 
   # Ensure the packages index is available before workers start.
   # Enqueue the initial package.
-  enqueuePackage(argument)
+  enqueuePackage(packageArg)
 
   var threads: array[WorkerCount, Thread[int]]
   for i in 0 ..< WorkerCount:
@@ -631,6 +732,8 @@ proc updateSinglePackage(packageName: string) =
 
     nimbyQuit(noPackageMsg & updateAllMsg)
 
+  prepareWorkspace()
+
   let
     localPackage = packageName / packageName & ".nimble"
     globalPackage = getGlobalPackagesDir() / packageName / packageName & ".nimble"
@@ -659,6 +762,8 @@ proc walkPackages(path: string): seq[tuple[path: string, name: string]] =
 
 proc updateAllPackages() =
   ## Update all packages.
+  prepareWorkspace()
+
   var prompt =
     "This will update all packages, including global packages that affect " &
     "all workspaces.\nContinue?"
@@ -676,6 +781,7 @@ proc removePackage(argument: string) =
   ## Remove a package.
   if argument == "":
     nimbyQuit("No package specified for removal")
+  prepareWorkspace()
   info &"Removing package: {argument}"
   removeConfigPackage(argument)
   try:
@@ -703,6 +809,7 @@ proc listPackage(packageName: string) =
 
 proc listPackages(argument: string) =
   ## List all packages in the workspace.
+  prepareWorkspace()
   if argument != "":
     listPackage(argument)
   else:
@@ -726,6 +833,7 @@ proc treePackage(name, indent: string) =
 
 proc treePackages(argument: string) =
   ## Tree the package dependencies.
+  prepareWorkspace()
   if argument != "":
     treePackage(argument, "")
   else:
@@ -741,9 +849,9 @@ proc checkPackage(packageName: string) =
     for dependency in nimbleFile.dependencies:
       if not dirExists(dependency.name):
         print &"Dependency `{dependency.name}` not found for package `{packageName}`."
-    if not fileExists(&"nim.cfg"):
+    if not fileExists(workspaceFile):
       nimbyQuit(&"Package `nim.cfg` not found.")
-    let nimCfg = readFileSafe("nim.cfg")
+    let nimCfg = readFileSafe(workspaceFile)
     if not nimCfg.contains(&"--path:\"{packageName}/") and not nimCfg.contains(&"--path:\"{packageName}\""):
       print &"Package `{packageName}` not found in nim.cfg."
   except NimbleFileNotFound:
@@ -754,6 +862,7 @@ proc doctorPackage(argument: string) =
   # Walk through all packages.
   # Ensure the workspace root has a nim.cfg entry.
   # Ensure all dependencies are installed.
+  prepareWorkspace()
   if argument != "":
     if not dirExists(argument):
       nimbyQuit(&"Package `{argument}` not found.")
@@ -761,11 +870,11 @@ proc doctorPackage(argument: string) =
     checkPackage(packageName)
   else:
     var lines: seq[string]
-    if fileExists("nim.cfg"):
-      let cfg = readFile("nim.cfg")
+    if fileExists(workspaceFile):
+      let cfg = readFile(workspaceFile)
       lines = cfg.split('\n')
 
-    if lines.len == 0 or lines[0] != "# Created by Nimby":
+    if lines.len == 0 or not hasMarker(lines.join("\n")):
       nimbyQuit("Working dir is not a Nimby workspace")
 
     var packageNames: seq[string]
@@ -797,6 +906,7 @@ proc doctorPackage(argument: string) =
 
 proc lockPackage(packageName: string) =
   ## Generate a lock file for a package.
+  prepareWorkspace()
   try:
     var listedDeps = @[packageName]
 
@@ -821,13 +931,15 @@ proc lockPackage(packageName: string) =
 
 proc syncPackage(path: string) =
   ## Synchronize packages from a lock file.
-  info &"Syncing lock file: {path}"
+  let lockPath = prepareWorkspace(path)
+
+  info &"Syncing lock file: {lockPath}"
   timeStart()
 
-  if not fileExists(path):
-    nimbyQuit(&"Package lock file `{path}` not found.")
+  if not fileExists(lockPath):
+    nimbyQuit(&"Package lock file `{lockPath}` not found.")
 
-  for line in readFileSafe(path).splitLines():
+  for line in readFileSafe(lockPath).splitLines():
     let parts = line.split(" ")
     if parts.len != 4:
       continue
@@ -945,9 +1057,10 @@ proc installNim(nimVersion: string) =
 when isMainModule:
   writeVersion()
 
-  var subcommand, argument: string
-  var all = false
-  var p = initOptParser()
+  var
+    subcommand, argument: string
+    all = false
+    p = initOptParser()
   for kind, key, val in p.getopt():
     case kind
     of cmdArgument:
@@ -988,6 +1101,7 @@ when isMainModule:
   try:
     case subcommand
       of "": writeHelp()
+      of "create": createWorkspace()
       of "install": installPackage(argument)
       of "sync": syncPackage(argument)
       of "update":

--- a/src/nimby.nim
+++ b/src/nimby.nim
@@ -288,6 +288,7 @@ proc writeHelp() =
   print "  doctor     diagnose all packages and fix linking issues"
   print "  lock       generate a lock file for a package"
   print "  sync       synchronize packages from a lock file"
+  print "  use        install a Nim compiler version"
   print "  help       show this help message"
 
 proc isGitUrl*(candidate: string): bool =

--- a/src/nimby.nim
+++ b/src/nimby.nim
@@ -29,6 +29,7 @@ type
   NimbleFile* = ref object
     version*: string
     srcDir*: string
+    bin*: seq[string]
     installDir*: string
     nimDependency*: Dependency
     dependencies*: seq[Dependency]
@@ -279,17 +280,18 @@ proc writeHelp() =
   print "    -h, --help show this help message"
   print "    -V, --verbose print verbose output"
   print "Subcommands:"
-  print "  create     create a Nimby workspace in the current directory"
-  print "  install    install Nim packages into the current workspace"
-  print "  update     update all Nim packages in the current directory"
-  print "  remove     remove all Nim packages in the current directory"
-  print "  list       list all Nim packages in the current directory"
-  print "  tree       show all packages as a dependency tree"
-  print "  doctor     diagnose all packages and fix linking issues"
-  print "  lock       generate a lock file for a package"
-  print "  sync       synchronize packages from a lock file"
-  print "  use        install a Nim compiler version"
-  print "  help       show this help message"
+  print "  create        create a Nimby workspace in the current directory"
+  print "  install       install Nim packages into the current workspace"
+  print "  update        update all Nim packages in the current directory"
+  print "  remove        remove all Nim packages in the current directory"
+  print "  list          list all Nim packages in the current directory"
+  print "  tree          show all packages as a dependency tree"
+  print "  doctor        diagnose all packages and fix linking issues"
+  print "  lock          generate a lock file for a package"
+  print "  lock build    build a package after verifying locked dependencies"
+  print "  sync          synchronize packages from a lock file"
+  print "  use           install a Nim compiler version"
+  print "  help          show this help message"
 
 proc isGitUrl*(candidate: string): bool =
   ## Check if a string is a git URL.
@@ -326,6 +328,12 @@ proc parseNimbleFile*(fileName: string): NimbleFile =
       result.version = line.split(" ")[^1].strip().replace("\"", "")
     elif line.startsWith("srcDir"):
       result.srcDir = line.split(" ")[^1].strip().replace("\"", "")
+    elif line.startsWith("bin"):
+      let raw = line.split("=", 1)[^1].strip()
+      for item in raw.split(","):
+        let name = item.strip().replace("\"", "").replace("@[", "").replace("]", "")
+        if name != "":
+          result.bin.add(name)
     elif line.startsWith("requires"):
       var i = 9
       var dependency, op, version = ""
@@ -946,6 +954,52 @@ proc lockPackage(packageName: string) =
     let errorMessage = &"Can't generate a lock file for '{packageName}'.\n"
     nimbyQuit(errorMessage & e.msg)
 
+proc findNimbleFile(dir: string): string =
+  for kind, child in walkDir(dir):
+    if kind == pcFile and child.endsWith(".nimble"):
+      return child
+  return ""
+
+proc lockBuild() =
+  let dir = getCurrentDir()
+  let nimbleFilePath = findNimbleFile(dir)
+  if nimbleFilePath == "":
+    nimbyQuit("No .nimble file found in the current directory.")
+  let lockPath = dir / "nimby.lock"
+  if not fileExists(lockPath):
+    nimbyQuit("No nimby.lock file found in the current directory.")
+
+  let workspace = findWorkspace(dir, autoCreate = false)
+
+  for line in readFileSafe(lockPath).splitLines():
+    let parts = line.split(" ")
+    if parts.len != 4:
+      continue
+    let
+      packageName = parts[0]
+      expectedHash = parts[3]
+      packagePath = workspace / packageName
+    if not dirExists(packagePath):
+      nimbyQuit(&"Dependency `{packageName}` not found in workspace.")
+    if not isCleanRepo(packagePath):
+      nimbyQuit(&"Dependency `{packageName}` has uncommitted changes.")
+    let actualHash = runOnce(&"git -C {packagePath} rev-parse HEAD")
+    if actualHash != expectedHash:
+      nimbyQuit(&"Dependency `{packageName}` is not at the locked commit.")
+
+  let nimbleFile = parseNimbleFile(nimbleFilePath)
+  if nimbleFile.bin.len == 0:
+    nimbyQuit("No bin target found in .nimble file.")
+  let srcDir = if nimbleFile.srcDir != "": nimbleFile.srcDir else: "src"
+  let srcPath = dir / srcDir
+  if not dirExists(srcPath):
+    nimbyQuit(&"Source directory `{srcDir}` not found.")
+  let binName = nimbleFile.bin[0]
+  let binPath = dir / srcDir / binName & ".nim"
+  let output = runOnce(&"nim c {binPath}")
+  if output != "":
+    print output
+
 proc syncPackage(path: string) =
   ## Synchronize packages from a lock file.
   let lockPath = prepareWorkspace(path)
@@ -1131,7 +1185,11 @@ when isMainModule:
       of "remove", "uninstall": removePackage(argument)
       of "list": listPackages(argument)
       of "tree": treePackages(argument)
-      of "lock": lockPackage(argument)
+      of "lock":
+        if argument == "build":
+          lockBuild()
+        else:
+          lockPackage(argument)
       of "use": installNim(argument)
       of "doctor": doctorPackage(argument)
       of "help": writeHelp()

--- a/src/nimby.nim
+++ b/src/nimby.nim
@@ -280,7 +280,7 @@ proc writeHelp() =
   print "    -V, --verbose print verbose output"
   print "Subcommands:"
   print "  create     create a Nimby workspace in the current directory"
-  print "  install    install all Nim packages in the current directory"
+  print "  install    install Nim packages into the current workspace"
   print "  update     update all Nim packages in the current directory"
   print "  remove     remove all Nim packages in the current directory"
   print "  list       list all Nim packages in the current directory"
@@ -685,24 +685,40 @@ proc prepareWorkspace(argument: string): string =
   result = normalizePathArgument(argument, startDir)
   setCurrentDir(findWorkspace(startDir))
 
-proc installPackage(argument: string) =
-  ## Install a package.
-  let packageArg =
-    if argument.endsWith(".nimble"):
-      prepareWorkspace(argument)
-    else:
-      prepareWorkspace()
-      argument
+proc parseInstallArgs(arguments: seq[string]): seq[string] =
+  ## Split package arguments by commas and trim shell-friendly separators.
+  for argument in arguments:
+    for packageArg in argument.split(','):
+      let packageArg = packageArg.strip()
+      if packageArg != "":
+        result.add(packageArg)
 
+proc installPackages(arguments: seq[string]) =
+  ## Install packages.
+  var packageArgs = parseInstallArgs(arguments)
+
+  if packageArgs.len == 0:
+    nimbyQuit("No package specified for install.")
+
+  for packageArg in packageArgs:
+    if packageArg in [".", "./", ".\\"]:
+      nimbyQuit("Refusing to install the current directory.")
+
+  let startDir = getCurrentDir()
+  for packageArg in packageArgs.mitems:
+    if packageArg.endsWith(".nimble"):
+      packageArg = normalizePathArgument(packageArg, startDir)
+
+  setCurrentDir(findWorkspace(startDir))
   timeStart()
-  print &"Installing package: {packageArg}"
 
-  if dirExists(packageArg):
-    nimbyQuit("Package already installed.")
+  for packageArg in packageArgs:
+    print &"Installing package: {packageArg}"
 
-  # Ensure the packages index is available before workers start.
-  # Enqueue the initial package.
-  enqueuePackage(packageArg)
+    if dirExists(packageArg):
+      nimbyQuit("Package already installed.")
+
+    enqueuePackage(packageArg)
 
   var threads: array[WorkerCount, Thread[int]]
   for i in 0 ..< WorkerCount:
@@ -1060,6 +1076,7 @@ when isMainModule:
 
   var
     subcommand, argument: string
+    arguments: seq[string]
     all = false
     p = initOptParser()
   for kind, key, val in p.getopt():
@@ -1069,6 +1086,7 @@ when isMainModule:
         subcommand = key
       else:
         argument = key
+        arguments.add(key)
     of cmdLongOption, cmdShortOption:
       case key
       of "help", "h":
@@ -1103,7 +1121,7 @@ when isMainModule:
     case subcommand
       of "": writeHelp()
       of "create": createWorkspace()
-      of "install": installPackage(argument)
+      of "install": installPackages(arguments)
       of "sync": syncPackage(argument)
       of "update":
         if all:

--- a/tests/test_commands.nim
+++ b/tests/test_commands.nim
@@ -27,6 +27,10 @@ proc cmdFailAt*(workingDir, command: string): string {.discardable.} =
   echo output.indent(4)
   check exitCode != 0
 
+proc cmdFail*(command: string): string {.discardable.} =
+  ## Runs a shell command in the test workspace that is expected to fail.
+  cmdFailAt(testWorkspace, command)
+
 proc branch(repo: string): string =
   cmd(&"git -C {repo} rev-parse --abbrev-ref HEAD").strip
 
@@ -64,10 +68,27 @@ suite "`nimby install` should":
     setupTestPackages()
     clean()
 
+  test "require a package argument":
+    let output = cmdFail("nimby install")
+    check output.contains("No package specified for install.")
+    check not fileExists("nim.cfg")
+
+  test "refuse to install the current directory":
+    let output = cmdFail("nimby install .")
+    check output.contains("Refusing to install the current directory.")
+    check not fileExists("nim.cfg")
+
   test "create the package locally":
     cmd("nimby install -V mummy")
     check dirExists("mummy")
     cmd("nimby remove mummy")
+
+  test "install multiple packages from one command line":
+    createTestPackage("package")
+    createTestPackage("dependency")
+    cmd(&"nimby install file://{testPackagesDir}/package, file://{testPackagesDir}/dependency")
+    check dirExists("package")
+    check dirExists("dependency")
 
   test "create the package globally when used with `-g`":
     cmd("nimby install -g -V mummy")

--- a/tests/test_commands.nim
+++ b/tests/test_commands.nim
@@ -278,6 +278,191 @@ suite "`nimby lock` should":
 
     check not actual.contains("nimbytestpackage")
 
+suite "`nimby lock build` should":
+  setup:
+    setupTestPackages()
+    clean()
+
+  test "fail when no .nimble file is present":
+    cmd("nimby create")
+    let output = cmdFail("nimby lock build")
+    check output.contains(".nimble")
+
+  test "fail when .nimble has no bin field":
+    cmd("nimby create")
+    createTestPackage("myapp")
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    writeFile(testWorkspace / "myapp" / "nimby.lock", "")
+
+    let output = cmdFailAt(testWorkspace / "myapp", "nimby lock build")
+    check output.contains("No bin target found")
+
+  test "build with default srcDir when .nimble omits it":
+    cmd("nimby create")
+    createTestPackage("myapp")
+
+    # Rewrite .nimble without srcDir but with bin
+    let nimblePath = testPackagesDir / "myapp" / "myapp.nimble"
+    writeFile(nimblePath, """
+# Package
+version       = "0.1.0"
+author        = "Test"
+description   = "Test"
+license       = "MIT"
+bin           = @["myapp"]
+
+# Dependencies
+requires "nim >= 2.0.0"
+""")
+    writeFile(testPackagesDir / "myapp" / "src" / "myapp.nim", "echo \"default_src\"\n")
+    let (_, _) = execCmdEx("git add -A && git commit -m 'no srcDir'",
+      workingDir = testPackagesDir / "myapp")
+
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    writeFile(testWorkspace / "myapp" / "nimby.lock", "")
+
+    cmdAt(testWorkspace / "myapp", "nimby lock build")
+
+  test "fail when srcDir does not exist":
+    cmd("nimby create")
+    createTestPackage("myapp")
+
+    # Set srcDir to a nonexistent directory
+    let nimblePath = testPackagesDir / "myapp" / "myapp.nimble"
+    writeFile(nimblePath, """
+# Package
+version       = "0.1.0"
+author        = "Test"
+description   = "Test"
+license       = "MIT"
+srcDir        = "missing"
+bin           = @["myapp"]
+
+# Dependencies
+requires "nim >= 2.0.0"
+""")
+    let (_, _) = execCmdEx("git add -A && git commit -m 'bad srcDir'",
+      workingDir = testPackagesDir / "myapp")
+
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    writeFile(testWorkspace / "myapp" / "nimby.lock", "")
+
+    let output = cmdFailAt(testWorkspace / "myapp", "nimby lock build")
+    check output.contains("missing")
+
+  test "fail when a dependency directory is missing":
+    cmd("nimby create")
+    createTestPackage("dep")
+    createTestPackage("myapp", requires = [&"file://{testPackagesDir}/dep"])
+
+    let nimblePath = testPackagesDir / "myapp" / "myapp.nimble"
+    var nimble = readFile(nimblePath)
+    nimble = nimble.replace("srcDir        = \"src\"", "srcDir        = \"src\"\nbin           = @[\"myapp\"]")
+    writeFile(nimblePath, nimble)
+    writeFile(testPackagesDir / "myapp" / "src" / "myapp.nim", "echo \"built\"\n")
+    let (_, _) = execCmdEx("git add -A && git commit -m 'add bin'",
+      workingDir = testPackagesDir / "myapp")
+
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    writeFile(testWorkspace / "myapp" / "nimby.lock", cmd("nimby lock myapp"))
+
+    # Remove the dependency from the workspace
+    removeDir(testWorkspace / "dep")
+
+    let output = cmdFailAt(testWorkspace / "myapp", "nimby lock build")
+    check output.contains("dep")
+    check output.contains("not found")
+
+  test "fail when no lock file is present":
+    cmd("nimby create")
+    createTestPackage("myapp")
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    let output = cmdFailAt(testWorkspace / "myapp", "nimby lock build")
+    check output.contains("nimby.lock")
+
+  test "fail when the build has a compilation error":
+    cmd("nimby create")
+    createTestPackage("myapp")
+
+    let nimblePath = testPackagesDir / "myapp" / "myapp.nimble"
+    var nimble = readFile(nimblePath)
+    nimble = nimble.replace("srcDir        = \"src\"", "srcDir        = \"src\"\nbin           = @[\"myapp\"]")
+    writeFile(nimblePath, nimble)
+    writeFile(testPackagesDir / "myapp" / "src" / "myapp.nim", "this is not valid nim\n")
+    let (_, _) = execCmdEx("git add -A && git commit -m 'broken source'",
+      workingDir = testPackagesDir / "myapp")
+
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    writeFile(testWorkspace / "myapp" / "nimby.lock", "")
+
+    let output = cmdFailAt(testWorkspace / "myapp", "nimby lock build")
+    check output.contains("error")
+
+  test "build successfully with an empty lock file":
+    cmd("nimby create")
+    createTestPackage("myapp")
+
+    let nimblePath = testPackagesDir / "myapp" / "myapp.nimble"
+    var nimble = readFile(nimblePath)
+    nimble = nimble.replace("srcDir        = \"src\"", "srcDir        = \"src\"\nbin           = @[\"myapp\"]")
+    writeFile(nimblePath, nimble)
+    writeFile(testPackagesDir / "myapp" / "src" / "myapp.nim", "echo \"no_deps\"\n")
+    let (_, _) = execCmdEx("git add -A && git commit -m 'add bin'",
+      workingDir = testPackagesDir / "myapp")
+
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    writeFile(testWorkspace / "myapp" / "nimby.lock", "")
+
+    cmdAt(testWorkspace / "myapp", "nimby lock build")
+
+  test "fail when a dependency is not at the locked commit":
+    cmd("nimby create")
+    createTestPackage("dep")
+    createTestPackage("myapp", requires = [&"file://{testPackagesDir}/dep"])
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    writeFile(testWorkspace / "myapp" / "nimby.lock", cmd("nimby lock myapp"))
+
+    # Advance dep past the locked commit
+    let (_, _) = execCmdEx(
+      "git commit --allow-empty -m 'advance'",
+      workingDir = testWorkspace / "dep"
+    )
+
+    let output = cmdFailAt(testWorkspace / "myapp", "nimby lock build")
+    check output.contains("dep")
+
+  test "fail when a dependency has uncommitted changes":
+    cmd("nimby create")
+    createTestPackage("dep")
+    createTestPackage("myapp", requires = [&"file://{testPackagesDir}/dep"])
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    writeFile(testWorkspace / "myapp" / "nimby.lock", cmd("nimby lock myapp"))
+
+    # Dirty the dep repo
+    writeFile(testWorkspace / "dep" / "dirty.txt", "uncommitted")
+
+    let output = cmdFailAt(testWorkspace / "myapp", "nimby lock build")
+    check output.contains("dep")
+
+  test "build the binary from srcDir and bin":
+    cmd("nimby create")
+    createTestPackage("dep")
+    createTestPackage("myapp", requires = [&"file://{testPackagesDir}/dep"])
+
+    # Add a bin field and a compilable main to the source package
+    let nimblePath = testPackagesDir / "myapp" / "myapp.nimble"
+    var nimble = readFile(nimblePath)
+    nimble = nimble.replace("srcDir        = \"src\"", "srcDir        = \"src\"\nbin           = @[\"myapp\"]")
+    writeFile(nimblePath, nimble)
+    writeFile(testPackagesDir / "myapp" / "src" / "myapp.nim", "echo \"built\"\n")
+    let (_, _) = execCmdEx("git add -A && git commit -m 'add bin'",
+      workingDir = testPackagesDir / "myapp")
+
+    cmd(&"nimby install file://{testPackagesDir}/myapp")
+    writeFile(testWorkspace / "myapp" / "nimby.lock", cmd("nimby lock myapp"))
+
+    cmdAt(testWorkspace / "myapp", "nimby lock build")
+
 suite "`nimby update` should":
   setup:
     setupTestPackages()

--- a/tests/test_commands.nim
+++ b/tests/test_commands.nim
@@ -63,6 +63,45 @@ suite "`nimby create` should":
     check fileExists(testWorkspace / "nim.cfg")
     check fileExists(nested / "nim.cfg")
 
+  test "succeed when run twice without duplicating the marker":
+    cmd("nimby create")
+    cmd("nimby create")
+    let content = readFile(testWorkspace / "nim.cfg")
+    check content.count("# Managed by Nimby") == 1
+
+  test "succeed explicitly inside a Git checkout":
+    let repo = testWorkspace / "repo"
+    createDir(repo)
+    createDir(repo / ".git")
+
+    cmdAt(repo, "nimby create")
+
+    check fileExists(repo / "nim.cfg")
+    check readFile(repo / "nim.cfg").contains("# Managed by Nimby")
+
+  test "succeed explicitly inside a Nimble package":
+    let package = testWorkspace / "package"
+    createDir(package)
+    writeFile(package / "package.nimble", "version = \"0.1.0\"\n")
+
+    cmdAt(package, "nimby create")
+
+    check fileExists(package / "nim.cfg")
+    check readFile(package / "nim.cfg").contains("# Managed by Nimby")
+
+  test "install into a nested workspace instead of parent":
+    cmd("nimby create")
+    let nested = testWorkspace / "nested"
+    createDir(nested)
+    cmdAt(nested, "nimby create")
+
+    createTestPackage("dependency")
+    cmdAt(nested, &"nimby install file://{testPackagesDir}/dependency")
+
+    check dirExists(nested / "dependency")
+    check not dirExists(testWorkspace / "dependency")
+    check readFile(nested / "nim.cfg").contains("dependency")
+
 suite "`nimby install` should":
   setup:
     setupTestPackages()
@@ -121,6 +160,22 @@ suite "`nimby install` should":
     let output = cmdFailAt(repo, &"nimby install file://{testPackagesDir}/dependency")
 
     check output.contains("No Nimby workspace found")
+    check output.contains("Refusing to create one inside package or Git checkout")
+    check not fileExists(repo / "nim.cfg")
+
+  test "refuse to auto-create inside a subdirectory of a Git checkout":
+    createTestPackage("dependency")
+    let repo = testWorkspace / "repo"
+    createDir(repo)
+    createDir(repo / ".git")
+    let subdir = repo / "src"
+    createDir(subdir)
+
+    let output = cmdFailAt(subdir, &"nimby install file://{testPackagesDir}/dependency")
+
+    check output.contains("No Nimby workspace found")
+    check output.contains("Refusing to create one inside package or Git checkout")
+    check not fileExists(subdir / "nim.cfg")
     check not fileExists(repo / "nim.cfg")
 
   test "refuse to auto-create inside Nimble packages":
@@ -132,6 +187,7 @@ suite "`nimby install` should":
     let output = cmdFailAt(package, &"nimby install file://{testPackagesDir}/dependency")
 
     check output.contains("No Nimby workspace found")
+    check output.contains("Refusing to create one inside package or Git checkout")
     check not fileExists(package / "nim.cfg")
 
   test "work on https:// urls":

--- a/tests/test_commands.nim
+++ b/tests/test_commands.nim
@@ -3,10 +3,10 @@ import testpackage
 
 let testWorkspace* = getTempDir() / "nimby_tests"
 
-proc cmd*(command: string): string {.discardable.} =
-  ## Runs a shell command in the test workspace, echoes output and returns it.
+proc cmdAt*(workingDir, command: string): string {.discardable.} =
+  ## Runs a shell command in a test directory, echoes output and returns it.
   echo "  > ", command
-  let (output, exitCode) = execCmdEx(command, workingDir = testWorkspace)
+  let (output, exitCode) = execCmdEx(command, workingDir = workingDir)
   result = output
   echo output.indent(4)
 
@@ -15,16 +15,49 @@ proc cmd*(command: string): string {.discardable.} =
 
   return output
 
+proc cmd*(command: string): string {.discardable.} =
+  ## Runs a shell command in the test workspace, echoes output and returns it.
+  cmdAt(testWorkspace, command)
+
+proc cmdFailAt*(workingDir, command: string): string {.discardable.} =
+  ## Runs a shell command that is expected to fail.
+  echo "  > ", command
+  let (output, exitCode) = execCmdEx(command, workingDir = workingDir)
+  result = output
+  echo output.indent(4)
+  check exitCode != 0
+
 proc branch(repo: string): string =
   cmd(&"git -C {repo} rev-parse --abbrev-ref HEAD").strip
 
 proc clean() =
   ## Resets the test workspace and global nimby directories.
+  setCurrentDir(getTempDir())
   removeDir(expandTilde("~/.nimby/nimbylock"))
   removeDir(expandTilde("~/.nimby/pkgs"))
   removeDir(testWorkspace)
   createDir(testWorkspace)
   setCurrentDir(testWorkspace)
+
+suite "`nimby create` should":
+  setup:
+    setupTestPackages()
+    clean()
+
+  test "create a workspace in the current directory":
+    cmd("nimby create")
+    check fileExists("nim.cfg")
+    check readFile("nim.cfg").contains("# Managed by Nimby")
+
+  test "create nested workspaces explicitly":
+    cmd("nimby create")
+    let nested = testWorkspace / "nested"
+    createDir(nested)
+
+    cmdAt(nested, "nimby create")
+
+    check fileExists(testWorkspace / "nim.cfg")
+    check fileExists(nested / "nim.cfg")
 
 suite "`nimby install` should":
   setup:
@@ -45,6 +78,40 @@ suite "`nimby install` should":
     createTestPackage("package")
     cmd(&"nimby install file://{testPackagesDir}/package")
     check dirExists("package")
+    check readFile("nim.cfg").contains("# Managed by Nimby")
+
+  test "use a parent workspace from nested directories":
+    cmd("nimby create")
+    createTestPackage("dependency")
+    let nested = testWorkspace / "nested"
+    createDir(nested)
+
+    cmdAt(nested, &"nimby install file://{testPackagesDir}/dependency")
+
+    check dirExists(testWorkspace / "dependency")
+    check not fileExists(nested / "nim.cfg")
+
+  test "refuse to auto-create inside Git checkouts":
+    createTestPackage("dependency")
+    let repo = testWorkspace / "repo"
+    createDir(repo)
+    createDir(repo / ".git")
+
+    let output = cmdFailAt(repo, &"nimby install file://{testPackagesDir}/dependency")
+
+    check output.contains("No Nimby workspace found")
+    check not fileExists(repo / "nim.cfg")
+
+  test "refuse to auto-create inside Nimble packages":
+    createTestPackage("dependency")
+    let package = testWorkspace / "package"
+    createDir(package)
+    writeFile(package / "package.nimble", "version = \"0.1.0\"\n")
+
+    let output = cmdFailAt(package, &"nimby install file://{testPackagesDir}/dependency")
+
+    check output.contains("No Nimby workspace found")
+    check not fileExists(package / "nim.cfg")
 
   test "work on https:// urls":
     cmd("nimby install https://github.com/treeform/nimbytestpackage.git")
@@ -116,7 +183,7 @@ suite "`nimby lock` should":
 
   test "include dependencies in the package with their corresponding URLs":
     cmd("nimby install https://github.com/RowDaBoat/nimbytestpackage.git")
-    cmd("nimby lock nimbytestpackage > nimbytestpackage.lock")
+    writeFile("nimbytestpackage.lock", cmd("nimby lock nimbytestpackage"))
     check fileExists("nimbytestpackage.lock")
     let
       lockOut = readFile("nimbytestpackage.lock")
@@ -166,7 +233,7 @@ suite "`nimby update` should":
   test "update global packages with -g":
     cmd("nimby install -g https://github.com/RowDaBoat/nimbytestpackage.git")
     let
-      repoPath = "~/.nimby/pkgs/nimbytestpackage"
+      repoPath = expandTilde("~/.nimby/pkgs/nimbytestpackage")
       present = rewindPackage(repoPath, "HEAD^")
 
     cmd("nimby update nimbytestpackage")
@@ -178,7 +245,7 @@ suite "`nimby update` should":
     cmd("nimby install -g https://github.com/treeform/bitty.git")
     cmd("nimby install https://github.com/RowDaBoat/nimbytestpackage.git")
     let
-      bittyPath = "~/.nimby/pkgs/bitty"
+      bittyPath = expandTilde("~/.nimby/pkgs/bitty")
       ntpPath = "nimbytestpackage"
       bittyPresent = rewindPackage(bittyPath, "HEAD^", "master")
       ntpPresent = rewindPackage(ntpPath, "HEAD^")

--- a/tests/testpackage.nim
+++ b/tests/testpackage.nim
@@ -61,7 +61,7 @@ requires "nim >= 2.0.0"
     &"git commit -m \"Initial commit for {name}\"",
   ]
 
-  for i in [1 ..< commits]:
+  for i in 1 ..< commits:
     commands.add &"git commit --allow-empty -m 'Commit {i}'"
 
   for command in commands:


### PR DESCRIPTION
## Summary

- Adds `nimby lock build` command for reproducible CI builds.
- Verifies all dependencies are at their locked commits with clean working trees before compiling.
- Parses `bin` and `srcDir` from the package's `.nimble` file to locate the build target.
- Fails fast with clear messages when: no `.nimble` found, no lock file, no `bin` field, `srcDir` missing, dependency not at locked commit, or dependency has uncommitted changes.

## Test plan

- [x] Fails when no `.nimble` file is present.
- [x] Fails when `.nimble` has no `bin` field.
- [x] Builds with default `srcDir` when `.nimble` omits it.
- [x] Fails when `srcDir` does not exist on disk.
- [x] Fails when no lock file is present.
- [x] Fails when a dependency directory is missing.
- [x] Fails when a dependency is not at the locked commit.
- [x] Fails when a dependency has uncommitted changes.
- [x] Fails when the source has a compilation error.
- [x] Builds successfully with an empty lock file (no deps).
- [x] Builds the binary from `srcDir` and `bin` with deps verified.