### PR TITLE
Isolate Git test configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,8 @@ jobs:
       - name: Run Nimby Unit Tests
         run: nim r tests/test_parsing.nim
 
+      - name: Test isolated Git configuration
+        run: nim r tests/test_gitconfig.nim
+
       - name: Run Nimby Functional Tests
         run: nim r tests/test_commands.nim

--- a/tests/test_gitconfig.nim
+++ b/tests/test_gitconfig.nim
@@ -1,0 +1,60 @@
+import std/[os, osproc, strformat, strutils]
+
+import testpackage
+
+proc testGitConfig() =
+  ## Checks that test Git settings do not alter the user configuration.
+  let
+    userConfigPath = expandTilde("~/.gitconfig")
+    userConfigExisted = fileExists(userConfigPath)
+    userConfigBefore =
+      if userConfigExisted:
+        readFile(userConfigPath)
+      else:
+        ""
+    ciExisted = existsEnv("CI")
+    ciBefore = getEnv("CI")
+    globalConfigExisted = existsEnv("GIT_CONFIG_GLOBAL")
+    globalConfigBefore = getEnv("GIT_CONFIG_GLOBAL")
+    packageName = &"gitconfig_{getCurrentProcessId()}"
+    packageDir = testPackagesDir / packageName
+
+  putEnv("CI", "1")
+  setupTestPackages()
+  if ciExisted:
+    putEnv("CI", ciBefore)
+  else:
+    delEnv("CI")
+
+  doAssert existsEnv("GIT_CONFIG_GLOBAL") == globalConfigExisted
+  doAssert getEnv("GIT_CONFIG_GLOBAL") == globalConfigBefore
+  doAssert fileExists(userConfigPath) == userConfigExisted
+  if userConfigExisted:
+    doAssert readFile(userConfigPath) == userConfigBefore
+
+  let
+    (rewrites, rewritesCode) = execCmdEx(
+      "git config --get-all url.https://github.com/.insteadOf"
+    )
+  doAssert rewritesCode == 0
+  doAssert rewrites.contains("ssh://git@github.com/")
+  doAssert rewrites.contains("git+ssh://git@github.com/")
+  doAssert rewrites.contains("git@github.com:")
+
+  if dirExists(packageDir):
+    removeDir(packageDir)
+  createTestPackage(packageName)
+  let
+    gitLogCommand = "git -C " & quoteShell(packageDir) &
+      " log -1 --format='%an <%ae>'"
+    (author, authorCode) = execCmdEx(gitLogCommand)
+  doAssert authorCode == 0
+  doAssert author.strip == "Tests <git@tests.com>"
+  removeDir(packageDir)
+
+  doAssert fileExists(userConfigPath) == userConfigExisted
+  if userConfigExisted:
+    doAssert readFile(userConfigPath) == userConfigBefore
+
+echo "Testing isolated Git configuration"
+testGitConfig()

--- a/tests/testpackage.nim
+++ b/tests/testpackage.nim
@@ -1,24 +1,26 @@
 import std/[os, osproc, sequtils, strutils, strformat]
 
+const GitCommit =
+  "git -c user.name=Tests -c user.email=git@tests.com commit"
+
 let testPackagesDir* = getTempDir() / "nimby_tests" / "packages"
 
 proc setupTestPackages*() =
+  ## Rewrites SSH URLs for Git child processes on CI.
   if not existsEnv("CI"):
     return
 
-  ## Configures git with test credentials and rewrites SSH URLs to HTTPS on CI.
-  var commands = @[
-    "git config --global user.email git@tests.com",
-    "git config --global user.name 'Tests'",
-    "git config --global --replace-all url.\"https://github.com/\".insteadOf \"ssh://git@github.com/\"",
-    "git config --global --add url.\"https://github.com/\".insteadOf \"git+ssh://git@github.com/\"",
-    "git config --global --add url.\"https://github.com/\".insteadOf \"git@github.com:\""
-  ]
-
-  for command in commands:
-    let (output, exitCode) = execCmdEx(command)
-    if exitCode != 0:
-      raise newException(Exception, &"Failed to set configure git:\n{command}\n{output}")
+  putEnv("GIT_CONFIG_COUNT", "3")
+  for i, url in [
+    "ssh://git@github.com/",
+    "git+ssh://git@github.com/",
+    "git@github.com:"
+  ]:
+    putEnv(
+      &"GIT_CONFIG_KEY_{i}",
+      "url.https://github.com/.insteadOf"
+    )
+    putEnv(&"GIT_CONFIG_VALUE_{i}", url)
 
 proc createTestPackage*(
   name: string,
@@ -58,11 +60,11 @@ requires "nim >= 2.0.0"
     "git init",
     &"git checkout -b {branch}",
     "git add -A",
-    &"git commit -m \"Initial commit for {name}\"",
+    &"{GitCommit} -m \"Initial commit for {name}\"",
   ]
 
   for i in [1 ..< commits]:
-    commands.add &"git commit --allow-empty -m 'Commit {i}'"
+    commands.add &"{GitCommit} --allow-empty -m 'Commit {i}'"
 
   for command in commands:
     let (output, exitCode) = execCmdEx(command, workingDir = packageDir)
@@ -73,7 +75,7 @@ proc addSubmodule*(repository: string, url: string) =
   ## Adds a git submodule at the given URL to the repository and commits it.
   let commands = [
     &"git -c protocol.file.allow=always submodule add {url}",
-    "git commit -m \"Add submodule\"",
+    &"{GitCommit} -m \"Add submodule\"",
   ]
 
   for command in commands:


### PR DESCRIPTION
## Summary

- pass the test identity only to individual fixture commit commands
- provide SSH-to-HTTPS rewrites through process-local Git environment entries
- add a regression test proving the user's global Git config remains unchanged

## Root cause

The functional test setup used `git config --global` for its fixture identity and URL rewrites. Running the suite locally with `CI=1` therefore overwrote the developer's real `~/.gitconfig`, and concurrent Git commands could observe the test identity.

This PR is based directly on `master` and contains only the Git configuration safety fix.

## Validation

- `nim check tests/test_commands.nim`
- `nim r tests/test_gitconfig.nim`
- `git diff --check origin/master...HEAD`
